### PR TITLE
Skip other drivers' devices in prepareDevices

### DIFF
--- a/cmd/power-dra-kubeletplugin/state.go
+++ b/cmd/power-dra-kubeletplugin/state.go
@@ -200,6 +200,11 @@ func (s *DeviceState) prepareDevices(claim *resourceapi.ResourceClaim) (Prepared
 	// each device allocation result based on their order of precedence.
 	configResultsMap := make(map[runtime.Object][]*resourceapi.DeviceRequestAllocationResult)
 	for i, result := range claim.Status.Allocation.Devices.Results {
+		// A claim may be satisfied by devices from several drivers; skip results
+		// for other drivers, the same way GetOpaqueDeviceConfigs skips their configs.
+		if result.Driver != DriverName {
+			continue
+		}
 		klog.Infof("Processing allocation result %d: Device=%v, Pool=%v, Request=%v", i, result.Device, result.Pool, result.Request)
 		if _, exists := s.allocatable[result.Device]; !exists {
 			klog.Errorf("Device %v not found in allocatable devices. Available devices: %v", result.Device, s.allocatable)

--- a/cmd/power-dra-kubeletplugin/state_test.go
+++ b/cmd/power-dra-kubeletplugin/state_test.go
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2025 - IBM Corporation. All rights reserved
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package main
+
+import (
+	"testing"
+
+	resourceapi "k8s.io/api/resource/v1"
+)
+
+// A claim can be satisfied by devices from several drivers. NodePrepareResources
+// must prepare only this driver's devices and skip the rest. Device names are
+// scoped by driver and pool, so another driver may legitimately use the same
+// device name as an Nx device; skipping by driver (not by allocatable presence)
+// keeps that foreign device from being silently prepared as an Nx device.
+func TestPrepareDevicesSkipsOtherDriverResults(t *testing.T) {
+	const nxDevice = "nx-0"
+	localResult := resourceapi.DeviceRequestAllocationResult{
+		Request: "nx",
+		Driver:  DriverName,
+		Pool:    "nx-pool",
+		Device:  nxDevice,
+	}
+	foreign := func(device string) resourceapi.DeviceRequestAllocationResult {
+		return resourceapi.DeviceRequestAllocationResult{
+			Request: "gpu",
+			Driver:  "gpu.example.com",
+			Pool:    "gpu-pool",
+			Device:  device,
+		}
+	}
+
+	tests := []struct {
+		name    string
+		results []resourceapi.DeviceRequestAllocationResult
+	}{
+		// The foreign device is not locally allocatable; the old code failed loudly.
+		{"foreign device not allocatable", []resourceapi.DeviceRequestAllocationResult{foreign("gpu-0"), localResult}},
+		// The foreign device reuses the local device name (valid across drivers); the
+		// old code passed the allocatable lookup and silently prepared it as an Nx device.
+		{"foreign name collides, foreign first", []resourceapi.DeviceRequestAllocationResult{foreign(nxDevice), localResult}},
+		{"foreign name collides, local first", []resourceapi.DeviceRequestAllocationResult{localResult, foreign(nxDevice)}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			state := &DeviceState{
+				allocatable: AllocatableDevices{nxDevice: resourceapi.Device{Name: nxDevice}},
+				cdi:         &CDIHandler{},
+			}
+			claim := &resourceapi.ResourceClaim{
+				Status: resourceapi.ResourceClaimStatus{
+					Allocation: &resourceapi.AllocationResult{
+						Devices: resourceapi.DeviceAllocationResult{Results: tc.results},
+					},
+				},
+			}
+
+			prepared, err := state.prepareDevices(claim)
+			if err != nil {
+				t.Fatalf("prepareDevices failed on a multi-driver claim: %v", err)
+			}
+			if len(prepared) != 1 {
+				t.Fatalf("prepared %d devices, want exactly one local Nx device: %#v", len(prepared), prepared)
+			}
+			got := prepared[0]
+			if got.DeviceName != nxDevice || got.PoolName != "nx-pool" ||
+				len(got.RequestNames) != 1 || got.RequestNames[0] != "nx" {
+				t.Fatalf("prepared %#v, want request=nx pool=nx-pool device=%s", got, nxDevice)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`prepareDevices` fails a claim that also contains another driver's device.

## The problem

The result loop in `prepareDevices` checks `s.allocatable[result.Device]` for every result in `claim.Status.Allocation.Devices.Results` and returns `requested Nx is not allocatable` when the device is missing. A ResourceClaim can be satisfied by devices from more than one driver, so when kubelet calls this driver's `NodePrepareResources` for such a claim, the results include the other drivers' devices too. Those are not in this driver's `allocatable` set, so the whole prepare fails.

Device names are only unique per driver and pool, so another driver may legitimately use the same name as an Nx device. In that case the foreign result passes the local allocatable lookup and is silently prepared as a second Nx device, which is worse than the loud failure above.

`GetOpaqueDeviceConfigs` in the same file already skips configs whose `Opaque.Driver` is not this driver, noting that a single request can be satisfied by different drivers. The result loop was missing the matching check.

## The change

Skip a result when `result.Driver != DriverName`, before the allocatable lookup and config selection, so `prepareDevices` prepares only this driver's devices.

`TestPrepareDevicesSkipsOtherDriverResults` is table-driven and covers both paths: a foreign device that is not locally allocatable (the loud error), and a foreign device that reuses the local device name in either order (the silent mis-prepare). Each case asserts a single prepared device carrying this driver's request, pool, and device, so the fix is locked to skipping by driver rather than by allocatable presence.

Fixes #322
